### PR TITLE
Fix missing NuGet package causing `dotnet build` failures during SF run

### DIFF
--- a/Modules/Intent.Modules.ModuleBuilder/Intent.ModuleBuilder.imodspec
+++ b/Modules/Intent.Modules.ModuleBuilder/Intent.ModuleBuilder.imodspec
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package>
   <id>Intent.ModuleBuilder</id>
-  <version>3.0.11</version>
+  <version>3.0.12</version>
   <supportedClientVersions>[3.0.0,4.0.0)</supportedClientVersions>
   <summary>For the creation of Intent Architect Modules</summary>
   <description>For the creation of Intent Architect Modules</description>

--- a/Modules/Intent.Modules.ModuleBuilder/Templates/Api/ApiElementModelExtensions/ApiElementModelExtensionsTemplatePartial.cs
+++ b/Modules/Intent.Modules.ModuleBuilder/Templates/Api/ApiElementModelExtensions/ApiElementModelExtensionsTemplatePartial.cs
@@ -1,13 +1,11 @@
 using System.Collections.Generic;
 using System.Linq;
 using Intent.Engine;
-using Intent.Metadata.Models;
-using Intent.Modules.Common;
-using Intent.Modules.Common.CSharp.Templates;
-using Intent.Modules.Common.Templates;
 using Intent.ModuleBuilder.Api;
+using Intent.Modules.Common;
+using Intent.Modules.Common.CSharp;
+using Intent.Modules.Common.CSharp.Templates;
 using Intent.RoslynWeaver.Attributes;
-using Intent.Templates;
 
 [assembly: DefaultIntentManaged(Mode.Merge)]
 [assembly: IntentTemplate("Intent.ModuleBuilder.CSharp.Templates.CSharpTemplatePartial", Version = "1.0")]
@@ -24,6 +22,8 @@ namespace Intent.Modules.ModuleBuilder.Templates.Api.ApiElementModelExtensions
         [IntentManaged(Mode.Merge, Signature = Mode.Fully)]
         public ApiElementModelExtensionsTemplate(IOutputTarget outputTarget, ExtensionModel model = null) : base(TemplateId, outputTarget, model)
         {
+            AddNugetDependency(IntentNugetPackages.IntentModulesCommon);
+
             foreach (var module in Model.StereotypeDefinitions
                 .SelectMany(x => x.TargetElements)
                 .Distinct()
@@ -47,39 +47,6 @@ namespace Intent.Modules.ModuleBuilder.Templates.Api.ApiElementModelExtensions
         public IEnumerable<string> DeclareUsings()
         {
             yield return Model.Type.ApiNamespace;
-        }
-    }
-
-    public class ExtensionModel
-    {
-        public IEnumerable<IStereotypeDefinition> StereotypeDefinitions { get; }
-        public ExtensionModelType Type { get; set; }
-
-        public ExtensionModel(ExtensionModelType type, IEnumerable<IStereotypeDefinition> stereotypeDefinitions)
-        {
-            StereotypeDefinitions = stereotypeDefinitions;
-            Type = type;
-        }
-
-        //public ElementSettingsModel Type { get; }
-
-        //public ExtensionModel(ElementSettingsModel element, IEnumerable<IStereotypeDefinition> stereotypeDefinitions)
-        //{
-        //    StereotypeDefinitions = stereotypeDefinitions;
-        //    Type = element;
-        //}
-    }
-
-    public class ExtensionModelType
-    {
-        private readonly IElement _element;
-        public string Name => _element.Name;
-        public string ApiNamespace => new IntentModuleModel(_element.Package).ApiNamespace;
-        public string ApiClassName => $"{Name.ToCSharpIdentifier()}Model";
-
-        public ExtensionModelType(IElement element)
-        {
-            _element = element;
         }
     }
 }

--- a/Modules/Intent.Modules.ModuleBuilder/Templates/Api/ApiElementModelExtensions/ExtensionModel.cs
+++ b/Modules/Intent.Modules.ModuleBuilder/Templates/Api/ApiElementModelExtensions/ExtensionModel.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using Intent.Metadata.Models;
+
+namespace Intent.Modules.ModuleBuilder.Templates.Api.ApiElementModelExtensions
+{
+    public class ExtensionModel
+    {
+        public ExtensionModel(ExtensionModelType type, IEnumerable<IStereotypeDefinition> stereotypeDefinitions)
+        {
+            StereotypeDefinitions = stereotypeDefinitions;
+            Type = type;
+        }
+
+        public IEnumerable<IStereotypeDefinition> StereotypeDefinitions { get; }
+
+        public ExtensionModelType Type { get; set; }
+    }
+}

--- a/Modules/Intent.Modules.ModuleBuilder/Templates/Api/ApiElementModelExtensions/ExtensionModelType.cs
+++ b/Modules/Intent.Modules.ModuleBuilder/Templates/Api/ApiElementModelExtensions/ExtensionModelType.cs
@@ -1,0 +1,22 @@
+using Intent.Metadata.Models;
+using Intent.ModuleBuilder.Api;
+using Intent.Modules.Common.CSharp.Templates;
+
+namespace Intent.Modules.ModuleBuilder.Templates.Api.ApiElementModelExtensions
+{
+    public class ExtensionModelType
+    {
+        private readonly IElement _element;
+
+        public ExtensionModelType(IElement element)
+        {
+            _element = element;
+        }
+
+        public string Name => _element.Name;
+
+        public string ApiNamespace => new IntentModuleModel(_element.Package).ApiNamespace;
+
+        public string ApiClassName => $"{Name.ToCSharpIdentifier()}Model";
+    }
+}

--- a/Modules/Intent.Modules.ModuleBuilder/Templates/Api/ApiPackageExtensionModel/ApiPackageExtensionModelTemplatePartial.cs
+++ b/Modules/Intent.Modules.ModuleBuilder/Templates/Api/ApiPackageExtensionModel/ApiPackageExtensionModelTemplatePartial.cs
@@ -1,11 +1,10 @@
-using System.Collections.Generic;
 using Intent.Engine;
 using Intent.Metadata.Models;
 using Intent.ModuleBuilder.Api;
+using Intent.Modules.Common.CSharp;
 using Intent.Modules.Common.CSharp.Templates;
 using Intent.Modules.Common.Templates;
 using Intent.RoslynWeaver.Attributes;
-using Intent.Templates;
 
 [assembly: DefaultIntentManaged(Mode.Merge)]
 [assembly: IntentTemplate("Intent.ModuleBuilder.CSharp.Templates.CSharpTemplatePartial", Version = "1.0")]
@@ -21,6 +20,7 @@ namespace Intent.Modules.ModuleBuilder.Templates.Api.ApiPackageExtensionModel
         [IntentManaged(Mode.Merge, Signature = Mode.Fully)]
         public ApiPackageExtensionModelTemplate(IOutputTarget outputTarget, PackageExtensionModel model) : base(TemplateId, outputTarget, model)
         {
+            AddNugetDependency(IntentNugetPackages.IntentModulesCommon);
         }
 
         protected override CSharpFileConfig DefineFileConfig()
@@ -35,12 +35,12 @@ namespace Intent.Modules.ModuleBuilder.Templates.Api.ApiPackageExtensionModel
             return new PackageSettingsModel((IElement)Model.TypeReference.Element);
         }
 
-        private string FormatForCollection(string name, bool asCollection)
+        private static string FormatForCollection(string name, bool asCollection)
         {
             return asCollection ? $"IList<{name}>" : name;
         }
 
-        private string GetCreationOptionName(ElementCreationOptionModel option)
+        private static string GetCreationOptionName(ElementCreationOptionModel option)
         {
             if (option.GetOptionSettings().ApiModelName() != null)
             {

--- a/Modules/Intent.Modules.ModuleBuilder/Templates/Api/ApiPackageModel/ApiPackageModelTemplatePartial.cs
+++ b/Modules/Intent.Modules.ModuleBuilder/Templates/Api/ApiPackageModel/ApiPackageModelTemplatePartial.cs
@@ -1,10 +1,9 @@
 using Intent.Engine;
 using Intent.ModuleBuilder.Api;
+using Intent.Modules.Common.CSharp;
 using Intent.Modules.Common.CSharp.Templates;
 using Intent.Modules.Common.Templates;
 using Intent.RoslynWeaver.Attributes;
-using Intent.Templates;
-using System.Collections.Generic;
 
 [assembly: DefaultIntentManaged(Mode.Merge)]
 [assembly: IntentTemplate("Intent.ModuleBuilder.CSharp.Templates.CSharpTemplatePartial", Version = "1.0")]
@@ -20,6 +19,7 @@ namespace Intent.Modules.ModuleBuilder.Templates.Api.ApiPackageModel
         [IntentManaged(Mode.Merge, Signature = Mode.Fully)]
         public ApiPackageModelTemplate(IOutputTarget outputTarget, PackageSettingsModel model) : base(TemplateId, outputTarget, model)
         {
+            AddNugetDependency(IntentNugetPackages.IntentModulesCommon);
         }
 
         protected override CSharpFileConfig DefineFileConfig()
@@ -29,12 +29,12 @@ namespace Intent.Modules.ModuleBuilder.Templates.Api.ApiPackageModel
                 @namespace: $"{Model.ParentModule.ApiNamespace}");
         }
 
-        private string FormatForCollection(string name, bool asCollection)
+        private static string FormatForCollection(string name, bool asCollection)
         {
             return asCollection ? $"IList<{name}>" : name;
         }
 
-        private string GetCreationOptionName(ElementCreationOptionModel option)
+        private static string GetCreationOptionName(ElementCreationOptionModel option)
         {
             if (option.GetOptionSettings().ApiModelName() != null)
             {

--- a/Modules/Intent.Modules.ModuleBuilder/Templates/Registration/Custom/CustomTemplateRegistrationTemplatePartial.cs
+++ b/Modules/Intent.Modules.ModuleBuilder/Templates/Registration/Custom/CustomTemplateRegistrationTemplatePartial.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using Intent.Engine;
 using Intent.ModuleBuilder.Api;
+using Intent.Modules.Common.CSharp;
 using Intent.Modules.Common.CSharp.Templates;
 using Intent.Modules.Common.Templates;
 using Intent.Modules.Common.Types.Api;
@@ -15,6 +16,8 @@ namespace Intent.Modules.ModuleBuilder.Templates.Registration.Custom
 
         public CustomTemplateRegistrationTemplate(IOutputTarget project, TemplateRegistrationModel model) : base(TemplateId, project, model)
         {
+            AddNugetDependency(IntentNugetPackages.IntentModulesCommon);
+
             if (!string.IsNullOrWhiteSpace(Model.GetModelType()?.ParentModule.NuGetPackageId))
             {
                 AddNugetDependency(new NugetPackageInfo(Model.GetModelType()?.ParentModule.NuGetPackageId, Model.GetModelType()?.ParentModule.NuGetPackageVersion));

--- a/Modules/Intent.Modules.ModuleBuilder/Templates/Registration/FilePerModel/FilePerModelTemplateRegistrationTemplatePartial.cs
+++ b/Modules/Intent.Modules.ModuleBuilder/Templates/Registration/FilePerModel/FilePerModelTemplateRegistrationTemplatePartial.cs
@@ -1,17 +1,13 @@
 using System.Collections.Generic;
 using System.Linq;
 using Intent.Engine;
-using Intent.Metadata.Models;
+using Intent.ModuleBuilder.Api;
 using Intent.Modules.Common;
 using Intent.Modules.Common.CSharp;
 using Intent.Modules.Common.CSharp.Templates;
 using Intent.Modules.Common.Templates;
 using Intent.Modules.Common.Types.Api;
 using Intent.Modules.Common.VisualStudio;
-using Intent.ModuleBuilder.Api;
-using Intent.Modules.ModuleBuilder.Templates.IModSpec;
-using Intent.RoslynWeaver.Attributes;
-using Intent.Templates;
 
 namespace Intent.Modules.ModuleBuilder.Templates.Registration.FilePerModel
 {
@@ -19,8 +15,10 @@ namespace Intent.Modules.ModuleBuilder.Templates.Registration.FilePerModel
     {
         public const string TemplateId = "Intent.ModuleBuilder.TemplateRegistration.FilePerModel";
 
-        public FilePerModelTemplateRegistrationTemplate(IProject project, TemplateRegistrationModel model) : base(TemplateId, project, model)
+        public FilePerModelTemplateRegistrationTemplate(IOutputTarget outputTarget, TemplateRegistrationModel model) : base(TemplateId, outputTarget, model)
         {
+            AddNugetDependency(IntentNugetPackages.IntentModulesCommon);
+
             if (!string.IsNullOrWhiteSpace(Model.GetModelType()?.ParentModule.NuGetPackageId))
             {
                 AddNugetDependency(new NugetPackageInfo(Model.GetModelType()?.ParentModule.NuGetPackageId, Model.GetModelType()?.ParentModule.NuGetPackageVersion));
@@ -32,8 +30,11 @@ namespace Intent.Modules.ModuleBuilder.Templates.Registration.FilePerModel
         }
 
         public string TemplateName => $"{Model.Name.ToCSharpIdentifier().RemoveSuffix("Template")}Template";
+
         public IList<string> OutputFolders => Model.GetParentFolders().Select(x => x.Name).Concat(new[] { Model.Name }).ToList();
+
         public string FolderPath => string.Join("/", OutputFolders);
+
         public string FolderNamespace => string.Join(".", OutputFolders);
 
         protected override CSharpFileConfig DefineFileConfig()
@@ -42,16 +43,6 @@ namespace Intent.Modules.ModuleBuilder.Templates.Registration.FilePerModel
                 className: $"{TemplateName}Registration",
                 @namespace: $"{OutputTarget.GetNamespace()}.{FolderNamespace}",
                 relativeLocation: $"{FolderPath}");
-        }
-
-        public override IEnumerable<INugetPackageInfo> GetNugetDependencies()
-        {
-            return new INugetPackageInfo[]
-            {
-                IntentNugetPackages.IntentModulesCommon
-            }
-            .Union(base.GetNugetDependencies())
-            .ToArray();
         }
 
         private string GetTemplateNameForTemplateId()

--- a/Modules/Intent.Modules.ModuleBuilder/Templates/Registration/SingleFileListModel/SingleFileListModelTemplateRegistrationTemplatePartial.cs
+++ b/Modules/Intent.Modules.ModuleBuilder/Templates/Registration/SingleFileListModel/SingleFileListModelTemplateRegistrationTemplatePartial.cs
@@ -1,15 +1,13 @@
 using System.Collections.Generic;
 using System.Linq;
 using Intent.Engine;
-using Intent.Metadata.Models;
+using Intent.ModuleBuilder.Api;
 using Intent.Modules.Common;
 using Intent.Modules.Common.CSharp;
 using Intent.Modules.Common.CSharp.Templates;
 using Intent.Modules.Common.Templates;
 using Intent.Modules.Common.Types.Api;
 using Intent.Modules.Common.VisualStudio;
-using Intent.ModuleBuilder.Api;
-using Intent.Templates;
 
 namespace Intent.Modules.ModuleBuilder.Templates.Registration.SingleFileListModel
 {
@@ -17,8 +15,10 @@ namespace Intent.Modules.ModuleBuilder.Templates.Registration.SingleFileListMode
     {
         public const string TemplateId = "Intent.ModuleBuilder.TemplateRegistration.SingleFileListModel";
 
-        public SingleFileListModelTemplateRegistrationTemplate(IProject project, TemplateRegistrationModel model) : base(TemplateId, project, model)
+        public SingleFileListModelTemplateRegistrationTemplate(IOutputTarget outputTarget, TemplateRegistrationModel model) : base(TemplateId, outputTarget, model)
         {
+            AddNugetDependency(IntentNugetPackages.IntentModulesCommon);
+
             if (!string.IsNullOrWhiteSpace(Model.GetModelType()?.ParentModule.NuGetPackageId))
             {
                 AddNugetDependency(new NugetPackageInfo(Model.GetModelType()?.ParentModule.NuGetPackageId, Model.GetModelType()?.ParentModule.NuGetPackageVersion));
@@ -30,8 +30,11 @@ namespace Intent.Modules.ModuleBuilder.Templates.Registration.SingleFileListMode
         }
 
         public string TemplateName => $"{Model.Name.ToCSharpIdentifier().RemoveSuffix("Template")}Template";
+
         public IList<string> OutputFolders => Model.GetParentFolders().Select(x => x.Name).Concat(new[] { Model.Name }).ToList();
+
         public string FolderPath => string.Join("/", OutputFolders);
+
         public string FolderNamespace => string.Join(".", OutputFolders);
 
         protected override CSharpFileConfig DefineFileConfig()
@@ -42,16 +45,6 @@ namespace Intent.Modules.ModuleBuilder.Templates.Registration.SingleFileListMode
                 relativeLocation: $"{FolderPath}");
         }
 
-        public override IEnumerable<INugetPackageInfo> GetNugetDependencies()
-        {
-            return new INugetPackageInfo[]
-            {
-                IntentNugetPackages.IntentModulesCommon
-            }
-            .Union(base.GetNugetDependencies())
-            .ToArray();
-        }
-        
         private string GetTemplateNameForTemplateId()
         {
             return TemplateName;

--- a/Modules/Intent.Modules.ModuleBuilder/Templates/Registration/SingleFileNoModel/SingleFileNoModelTemplateRegistrationTemplatePartial.cs
+++ b/Modules/Intent.Modules.ModuleBuilder/Templates/Registration/SingleFileNoModel/SingleFileNoModelTemplateRegistrationTemplatePartial.cs
@@ -1,15 +1,11 @@
 using System.Collections.Generic;
 using System.Linq;
 using Intent.Engine;
-using Intent.Metadata.Models;
-using Intent.Modules.Common;
+using Intent.ModuleBuilder.Api;
 using Intent.Modules.Common.CSharp;
 using Intent.Modules.Common.CSharp.Templates;
 using Intent.Modules.Common.Templates;
 using Intent.Modules.Common.Types.Api;
-using Intent.Modules.Common.VisualStudio;
-using Intent.ModuleBuilder.Api;
-using Intent.Templates;
 
 namespace Intent.Modules.ModuleBuilder.Templates.Registration.SingleFileNoModel
 {
@@ -17,13 +13,17 @@ namespace Intent.Modules.ModuleBuilder.Templates.Registration.SingleFileNoModel
     {
         public const string TemplateId = "Intent.ModuleBuilder.TemplateRegistration.SingleFileNoModel";
 
-        public SingleFileNoModelTemplateRegistrationTemplate(IProject project, TemplateRegistrationModel model) : base(TemplateId, project, model)
+        public SingleFileNoModelTemplateRegistrationTemplate(IOutputTarget outputTarget, TemplateRegistrationModel model) : base(TemplateId, outputTarget, model)
         {
+            AddNugetDependency(IntentNugetPackages.IntentModulesCommon);
         }
 
         public string TemplateName => $"{Model.Name.ToCSharpIdentifier().RemoveSuffix("Template")}Template";
+
         public IList<string> OutputFolders => Model.GetParentFolders().Select(x => x.Name).Concat(new[] { Model.Name }).ToList();
+
         public string FolderPath => string.Join("/", OutputFolders);
+
         public string FolderNamespace => string.Join(".", OutputFolders);
 
         protected override CSharpFileConfig DefineFileConfig()
@@ -32,16 +32,6 @@ namespace Intent.Modules.ModuleBuilder.Templates.Registration.SingleFileNoModel
                 className: $"{TemplateName}Registration",
                 @namespace: $"{OutputTarget.GetNamespace()}.{FolderNamespace}",
                 relativeLocation: $"{FolderPath}");
-        }
-
-        public override IEnumerable<INugetPackageInfo> GetNugetDependencies()
-        {
-            return new INugetPackageInfo[]
-            {
-                IntentNugetPackages.IntentModulesCommon
-            }
-            .Union(base.GetNugetDependencies())
-            .ToArray();
         }
 
         private string GetTemplateNameForTemplateId()


### PR DESCRIPTION
This primarily fixes the problem that if a module is made with the Module Builder which does nothing except a `designer extension` with custom elements with extensions, then the `Intent.Modules.Common` NuGet package wasn't being installed which resulted in `dotnet build` failing during the SF run.

Otherwise it does minor neatening up in the affected files.